### PR TITLE
Only add MDNS services if MDNS is enabled (default=true)

### DIFF
--- a/src/TelnetSerialStream.cpp
+++ b/src/TelnetSerialStream.cpp
@@ -68,7 +68,9 @@ void TelnetSerialStream::begin() {
     _serverClients[i] = NULL;
 
   Log.printf("Opened serial server on telnet://%s:%d\n", WiFi.localIP().toString().c_str(), _telnetPort);
-  MDNS.addService("telnet", "tcp", _telnetPort);
+  if (_withMDNS) {
+    MDNS.addService("telnet", "tcp", _telnetPort);
+  }
 };
 
 void TelnetSerialStream::stop() {

--- a/src/TelnetSerialStream.h
+++ b/src/TelnetSerialStream.h
@@ -29,8 +29,8 @@
 
 class TelnetSerialStream : public LOGBase {
   public:
-    TelnetSerialStream(String hostname, const uint16_t telnetPort = 23, const uint16_t maxClients = MAX_SERIAL_TELNET_CLIENTS) : _hostname(hostname), _telnetPort(telnetPort), _maxClients(maxClients) {};
-    TelnetSerialStream(const uint16_t telnetPort = 23, const uint16_t maxClients = MAX_SERIAL_TELNET_CLIENTS) : _telnetPort(telnetPort), _maxClients(maxClients) {};
+    TelnetSerialStream(String hostname, const uint16_t telnetPort = 23, const uint16_t maxClients = MAX_SERIAL_TELNET_CLIENTS, bool withMDNS = true) : _hostname(hostname), _telnetPort(telnetPort), _maxClients(maxClients), _withMDNS(withMDNS) {};
+    TelnetSerialStream(const uint16_t telnetPort = 23, const uint16_t maxClients = MAX_SERIAL_TELNET_CLIENTS, bool withMDNS = true) : _telnetPort(telnetPort), _maxClients(maxClients), _withMDNS(withMDNS) {};
     ~TelnetSerialStream();
     virtual size_t write(uint8_t c);
     virtual size_t write(uint8_t * buff, size_t len);
@@ -43,6 +43,7 @@ class TelnetSerialStream : public LOGBase {
     uint16_t _telnetPort, _maxClients;
     WiFiServer * _server = NULL;
     WiFiClient ** _serverClients;
+    bool _withMDNS;
   protected:
 };
 #endif

--- a/src/WebSerialStream.cpp
+++ b/src/WebSerialStream.cpp
@@ -103,7 +103,9 @@ void WebSerialStream::begin() {
   _server->begin();
 
   Log.printf("Opened serial web server on http://%s:%d\n", WiFi.localIP().toString().c_str(), _webPort);
-  MDNS.addService("http", "tcp", _webPort);
+  if (_withMDNS) {
+    MDNS.addService("http", "tcp", _webPort);
+  }
 };
 
 void WebSerialStream::stop() {

--- a/src/WebSerialStream.h
+++ b/src/WebSerialStream.h
@@ -39,7 +39,7 @@ typedef ESP8266WebServer WebServer;
 
 class WebSerialStream : public LOGBase {
   public:
-    WebSerialStream(const uint16_t webPort = 80) : _webPort(webPort) {};
+    WebSerialStream(const uint16_t webPort = 80, bool withMDNS = true) : _webPort(webPort), _withMDNS(withMDNS) {};
     ~WebSerialStream();
     virtual size_t write(uint8_t c);
     virtual void begin();
@@ -50,6 +50,7 @@ class WebSerialStream : public LOGBase {
     WebServer * _server = NULL;
     uint8_t _buff[1024];
     unsigned long _at = 0;
+    bool _withMDNS;
   protected:
 };
 #endif


### PR DESCRIPTION
This change makes MDNS optional if the HTTP or Telnet services are used. The defaults remain as they are today, but if someone (me) doesn't want to use MDNS then they shouldn't have to. Furthermore, I was chasing a crash where I wasn't calling `MDNS.begin(...)` (only with the HTTP service). This is avoidable entirely if MDNS is not used.
